### PR TITLE
Add skeletons for different parts/pages of the app

### DIFF
--- a/src/auth/ProtectedRoute.tsx
+++ b/src/auth/ProtectedRoute.tsx
@@ -5,7 +5,7 @@ const ProtectedRoute = () => {
   const { isAuthenticated, isLoading } = useAuth0();
 
   if (isLoading) {
-    return <span>ProtectedRoute Loading...</span>;
+    return <></>;
   }
 
   return isAuthenticated ? <Outlet /> : <Navigate to="/" replace />;

--- a/src/components/CheckoutButton.tsx
+++ b/src/components/CheckoutButton.tsx
@@ -59,11 +59,11 @@ const CheckoutButton = ({ onCheckout, disabled, isLoading }: Props) => {
   return (
     <Dialog>
       <DialogTrigger className="flex w-full">
-        <Button disabled={disabled} className="bg-blue-500 flex-1 mx-4 mb-6">
+        <Button disabled={disabled} className="bg-blue-500 dark:bg-blue-700 flex-1 mx-4 mb-6">
           Go to checkout
         </Button>
       </DialogTrigger>
-      <DialogContent className="bg-gray-50 md:min-w-[600px] max-w-[425px]">
+      <DialogContent className="bg-gray-50 dark:bg-gray-900 md:min-w-[600px] max-w-[425px]">
         <UserProfileForm
           currentUser={currentUser}
           onSave={onCheckout}

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -39,7 +39,7 @@ const MobileNav = () => {
             <MobileUserMenu />
           ) : (
             <Button
-              className="flex-1 font-bold  bg-blue-500 text-md"
+              className="flex-1 font-bold  bg-blue-500 dark:bg-blue-700 text-md"
               onClick={() => loginWithRedirect()}
             >
               <LogIn className="mr-2 h-6 w-5" />

--- a/src/components/MobileUserMenu.tsx
+++ b/src/components/MobileUserMenu.tsx
@@ -7,19 +7,19 @@ const MobileUserMenu = () => {
 
   return (
     <div className="flex flex-col gap-2 w-full text-black text-lg">
-      <div className="cursor-pointer flex-1 text-white hover:bg-black flex justify-center bg-blue-500 focus:bg-blue-500 rounded-md hover:text-white focus:text-white">
+      <div className="cursor-pointer flex-1 text-black dark:text-white hover:dark:text-black hover:dark:bg-white hover:bg-black flex justify-center bg-blue-500 dark:bg-blue-700 focus:dark:bg-blue-700 focus:bg-blue-500 rounded-md hover:text-white focus:text-white focus:dark:text-black">
         <Link to="/order-status" className="flex p-2 items-center justify-center w-full">
           <LoaderCircle className="mr-2 h-6 w-5" />
           <span>Order Status</span>
         </Link>
       </div>
-      <div className="cursor-pointer flex-1 text-white hover:bg-black flex justify-center bg-blue-500 focus:bg-blue-500 rounded-md hover:text-white focus:text-white">
+      <div className="cursor-pointer flex-1 text-black dark:text-white hover:dark:text-black hover:dark:bg-white hover:bg-black flex justify-center bg-blue-500 dark:bg-blue-700 focus:dark:bg-blue-700 focus:bg-blue-500 rounded-md hover:text-white focus:text-white focus:dark:text-black">
         <Link to="/manage-restaurant" className="flex p-2 items-center justify-center w-full">
           <UtensilsCrossed className="mr-2 h-6 w-5" />
           <span>My Restaurant</span>
         </Link>
       </div>
-      <div className="cursor-pointer flex-1 text-white hover:bg-black flex justify-center bg-blue-500 focus:bg-blue-500 rounded-md hover:text-white focus:text-white">
+      <div className="cursor-pointer flex-1 text-black dark:text-white hover:dark:text-black hover:dark:bg-white hover:bg-black flex justify-center bg-blue-500 dark:bg-blue-700 focus:dark:bg-blue-700 focus:bg-blue-500 rounded-md hover:text-white focus:text-white focus:dark:text-black">
         <Link to="/user-profile" className="flex p-2 items-center justify-center w-full">
           <User className="mr-2 h-6 w-5" />
           <span>Profile</span>
@@ -27,7 +27,7 @@ const MobileUserMenu = () => {
       </div>
       <div
         onClick={() => logout()}
-        className="cursor-pointer p-2 flex-1 ext-md flex items-center text-white hover:bg-black justify-center bg-blue-500 focus:bg-blue-500 rounded-md hover:text-white focus:text-white"
+        className="cursor-pointer p-2 flex-1 ext-md flex items-center text-black dark:text-white hover:dark:text-black hover:dark:bg-white hover:bg-black justify-center bg-blue-500 dark:bg-blue-700 focus:dark:bg-blue-700 focus:bg-blue-500 rounded-md hover:text-white focus:text-white focus:dark:text-black"
       >
         <LogOut className="mr-2 h-6 w-5" />
         <span>Log out</span>

--- a/src/components/OrderItemCard.tsx
+++ b/src/components/OrderItemCard.tsx
@@ -84,7 +84,7 @@ const OrderItemCard = ({ order }: Props) => {
             </div>
           ))}
         </div>
-        <div className="flex flex-col space-y-2">
+        <div className="flex flex-col space-y-4">
           <Label htmlFor="status">What is the status of this order?</Label>
           <Select
             disabled={isPending}

--- a/src/components/OrderItems.tsx
+++ b/src/components/OrderItems.tsx
@@ -1,0 +1,32 @@
+import { useGetMyRestaurantOrders } from "@/api/MyRestaurantApi";
+import OrderItemCard from "./OrderItemCard";
+import OrderItemCardSkeleton from "./skeletons/OrderItemCardSkeleton";
+import { Skeleton } from "./ui/skeleton";
+
+const OrderItems = () => {
+  const { orders, isLoading } = useGetMyRestaurantOrders();
+
+  if (isLoading) {
+    return (
+      <>
+        <Skeleton className="h-9 w-48" />
+        {new Array(5).fill(0).map((_, index) => (
+          <OrderItemCardSkeleton key={index} />
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <h2 className="font-bold text-2xl">
+        {orders?.length || 0} {(orders?.length || 0) > 1 ? "orders" : "order"}
+      </h2>
+      {orders?.map((order) => (
+        <OrderItemCard order={order} />
+      ))}
+    </>
+  );
+};
+
+export default OrderItems;

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -85,7 +85,7 @@ const SearchBar = ({ onSubmit, placeholder, onReset, searchQuery }: Props) => {
         >
           Reset
         </Button>
-        <Button type="submit" className="rounded-full bg-blue-500">
+        <Button type="submit" className="rounded-full bg-blue-500 dark:bg-blue-700">
           Search
         </Button>
       </form>

--- a/src/components/skeletons/CousineSectionSkeleton.tsx
+++ b/src/components/skeletons/CousineSectionSkeleton.tsx
@@ -1,0 +1,28 @@
+import { Checkbox } from "../ui/checkbox";
+import { Skeleton } from "../ui/skeleton";
+
+const CousineSectionSkeleton = () => {
+  return (
+    <div className="space-y-2">
+      <div>
+        <h2 className="font-bold text-2xl">Cuisines</h2>
+        <p className="text-sm">
+          Create a menu and give each item a name and a price
+        </p>
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-1">
+        {new Array(20).fill(0).map((_, index) => (
+          <div
+            key={index}
+            className="flex flex-row-reverse items-center gap-2 space-y-0 mt-2 justify-end"
+          >
+            <Skeleton className="w-24 lg:w-36 h-4 bg-background" />
+            <Checkbox className="bg-background" disabled />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CousineSectionSkeleton;

--- a/src/components/skeletons/CuisineFilterSkeleton.tsx
+++ b/src/components/skeletons/CuisineFilterSkeleton.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "../ui/skeleton";
+
+const CuisineFilterSkeleton = () => {
+  return (
+    <>
+      <div className="space-y-2 flex flex-col">
+        {new Array(10).fill(0).map((_, index) => {
+          return (
+            <Skeleton key={index} className="w-full md:w-60 h-9 rounded-full" />
+          );
+        })}
+        <div className="flex justify-center w-full">
+          <Skeleton className="h-6 w-20" />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default CuisineFilterSkeleton;

--- a/src/components/skeletons/DetailPageSkeleton.tsx
+++ b/src/components/skeletons/DetailPageSkeleton.tsx
@@ -1,0 +1,34 @@
+import { AspectRatio } from "@radix-ui/react-aspect-ratio";
+import { Skeleton } from "../ui/skeleton";
+import OrderInfoSkeleton from "./OrderInfoSkeleton";
+import RestaurantInfoSkeleton from "./RestaurantInfoSkeleton";
+
+const DetailPageSkeleton = () => {
+  return (
+    <div className="flex flex-col gap-10">
+      <AspectRatio ratio={16 / 5}>
+        <Skeleton className="rounded-md w-full h-full" />
+      </AspectRatio>
+      <div className="grid md:grid-cols-[4fr_2fr] gap-5 lg:px-28">
+        <div className="flex flex-col gap-4">
+          <RestaurantInfoSkeleton />
+          <span className="font-bold text-2xl">Menu</span>
+          {new Array(5).fill(0).map((_, index) => (
+            <Skeleton
+              key={index}
+              className="w-full h-28 p-4 flex flex-col justify-between"
+            >
+              <Skeleton className="w-40 h-6 bg-background" />
+              <Skeleton className="w-40 h-6 bg-background" />
+            </Skeleton>
+          ))}
+        </div>
+        <div>
+          <OrderInfoSkeleton />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DetailPageSkeleton;

--- a/src/components/skeletons/DetailsSectionSkeleton.tsx
+++ b/src/components/skeletons/DetailsSectionSkeleton.tsx
@@ -1,0 +1,36 @@
+import { Skeleton } from "../ui/skeleton";
+
+const DetailsSectionSkeleton = () => {
+  return (
+    <div className="space-y-2">
+      <div>
+        <h2 className="font-bold text-2xl">Details</h2>
+        <p className="text-sm">Enter the details about your restaurant</p>
+      </div>
+      <div className="flex flex-col flex-1 space-y-2">
+        <label>Name</label>
+        <Skeleton className="h-9 bg-background" />
+      </div>
+      <div className="flex flex-col md:flex-row gap-4">
+        <div className="flex flex-col flex-1 space-y-2">
+          <label>City</label>
+          <Skeleton className="h-9 bg-background" />
+        </div>
+        <div className="flex flex-col flex-1 space-y-2">
+          <label>Country</label>
+          <Skeleton className="h-9 bg-background" />
+        </div>
+      </div>
+      <div className="flex flex-col flex-1 space-y-2">
+        <label>Delivery Price (₹)</label>
+        <Skeleton className="h-9 bg-background md:w-80" />
+      </div>
+      <div className="flex flex-col flex-1 space-y-2">
+        <label>Estimated Delivery Time (in minutes)</label>
+        <Skeleton className="h-9 bg-background md:w-80" />
+      </div>
+    </div>
+  );
+};
+
+export default DetailsSectionSkeleton;

--- a/src/components/skeletons/ImageSectionSkeleton.tsx
+++ b/src/components/skeletons/ImageSectionSkeleton.tsx
@@ -1,0 +1,26 @@
+import { AspectRatio } from "../ui/aspect-ratio";
+import { Skeleton } from "../ui/skeleton";
+
+const ImageSectionSkeleton = () => {
+  return (
+    <div className="space-y-2">
+      <div>
+        <h2 className="font-bold text-2xl">Image</h2>
+        <p className="text-sm">
+          Add an image that will be displayed on your restaurant listing in the
+          search results. Adding a new image will overwrite the existing one.
+        </p>
+      </div>
+      <div className="sm:w-[450px]">
+        <AspectRatio ratio={16 / 9}>
+          <Skeleton className="w-full h-full bg-background" />
+        </AspectRatio>
+      </div>
+      <div className="w-[100%] sm:w-80">
+        <Skeleton className="h-9 bg-background" />
+      </div>
+    </div>
+  );
+};
+
+export default ImageSectionSkeleton;

--- a/src/components/skeletons/ManageRestaurantFormSkeleton.tsx
+++ b/src/components/skeletons/ManageRestaurantFormSkeleton.tsx
@@ -17,7 +17,7 @@ const ManageRestaurantFormSkeleton = () => {
       <MenuSectionSkeleton />
       <Separator />
       <ImageSectionSkeleton />
-      <Button type="submit" className="bg-blue-500 text-md" disabled>
+      <Button type="submit" className="bg-blue-500 dark:bg-blue-700 text-md" disabled>
         Submit
       </Button>
     </form>

--- a/src/components/skeletons/ManageRestaurantFormSkeleton.tsx
+++ b/src/components/skeletons/ManageRestaurantFormSkeleton.tsx
@@ -1,0 +1,27 @@
+import { Button } from "../ui/button";
+import { Separator } from "../ui/separator";
+import CousineSectionSkeleton from "./CousineSectionSkeleton";
+import DetailsSectionSkeleton from "./DetailsSectionSkeleton";
+import ImageSectionSkeleton from "./ImageSectionSkeleton";
+import MenuSectionSkeleton from "./MenuSectionSkeleton";
+
+const ManageRestaurantFormSkeleton = () => {
+  return (
+    <form
+      className="space-y-8 bg-gray-100 dark:bg-gray-900 rounded-lg p-4 sm:p-7 md:p-10"
+    >
+      <DetailsSectionSkeleton />
+      <Separator />
+      <CousineSectionSkeleton />
+      <Separator />
+      <MenuSectionSkeleton />
+      <Separator />
+      <ImageSectionSkeleton />
+      <Button type="submit" className="bg-blue-500 text-md" disabled>
+        Submit
+      </Button>
+    </form>
+  );
+};
+
+export default ManageRestaurantFormSkeleton;

--- a/src/components/skeletons/MenuSectionSkeleton.tsx
+++ b/src/components/skeletons/MenuSectionSkeleton.tsx
@@ -1,0 +1,35 @@
+import { Button } from "../ui/button";
+import { Skeleton } from "../ui/skeleton";
+
+const MenuSectionSkeleton = () => {
+  return (
+    <div className="space-y-2">
+      <div>
+        <h2 className="font-bold text-2xl">Menu</h2>
+        <p className="text-sm">
+          Create your menu and give each item a name and a price
+        </p>
+      </div>
+      <div className="flex flex-col gap-2">
+        {new Array(5).fill(0).map((_, index) => (
+          <div className="flex gap-2 items-end" key={index}>
+            <div className="flex flex-col gap-1 grow sm:grow-0">
+              <label>Name</label>
+              <Skeleton className="h-9 bg-background sm:w-40" />
+            </div>
+            <div className="flex flex-col gap-1 grow sm:grow-0">
+              <label>Price (₹)</label>
+              <Skeleton className="h-9 bg-background sm:w-40" />
+            </div>
+            <Button className="self-end" variant="destructive" disabled>
+              Remove
+            </Button>
+          </div>
+        ))}
+      </div>
+      <Button type="button" disabled>Add Menu Item</Button>
+    </div>
+  );
+};
+
+export default MenuSectionSkeleton;

--- a/src/components/skeletons/OrderInfoSkeleton.tsx
+++ b/src/components/skeletons/OrderInfoSkeleton.tsx
@@ -27,7 +27,7 @@ const OrderInfoSkeleton = () => {
         <Separator />
       </CardContent>
       <div className="px-6">
-        <Button disabled className="bg-blue-500 flex-1 mb-6 w-full">
+        <Button disabled className="bg-blue-500 dark:bg-blue-700 flex-1 mb-6 w-full">
           Go to checkout
         </Button>
       </div>

--- a/src/components/skeletons/OrderInfoSkeleton.tsx
+++ b/src/components/skeletons/OrderInfoSkeleton.tsx
@@ -1,0 +1,38 @@
+import { Button } from "../ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { Separator } from "../ui/separator";
+import { Skeleton } from "../ui/skeleton";
+
+const OrderInfoSkeleton = () => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex justify-between">
+          <Skeleton className="h-7 w-24" />
+          <Skeleton className="h-7 w-20" />
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-5">
+        {new Array(3).fill(0).map((_, index) => (
+          <div className="flex justify-between" key={index}>
+            <Skeleton className="h-6 w-20" />
+            <Skeleton className="h-6 w-16" />
+          </div>
+        ))}
+        <Separator />
+        <div className="flex justify-between">
+          <Skeleton className="h-6 w-20" />
+          <Skeleton className="h-6 w-16" />
+        </div>
+        <Separator />
+      </CardContent>
+      <div className="px-6">
+        <Button disabled className="bg-blue-500 flex-1 mb-6 w-full">
+          Go to checkout
+        </Button>
+      </div>
+    </Card>
+  );
+};
+
+export default OrderInfoSkeleton;

--- a/src/components/skeletons/OrderItemCardSkeleton.tsx
+++ b/src/components/skeletons/OrderItemCardSkeleton.tsx
@@ -1,0 +1,49 @@
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { Label } from "../ui/label";
+import { Separator } from "../ui/separator";
+import { Skeleton } from "../ui/skeleton";
+
+const OrderItemCardSkeleton = () => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex flex-row gap-4 justify-between mb-3">
+          <div className="flex gap-3 items-center">
+            Customer Name:
+            <Skeleton className="w-36 h-6" />
+          </div>
+          <div className="flex gap-3 items-center">
+            Delivery Address:
+            <Skeleton className="w-20 h-6" />
+            <Skeleton className="w-20 h-6" />
+          </div>
+          <div className="flex gap-3 items-center">
+            Time:
+            <Skeleton className="w-12 h-6" />
+          </div>
+          <div className="flex gap-3 items-center">
+            Total Cost:
+            <Skeleton className="w-12 h-6" />
+          </div>
+        </CardTitle>
+        <Separator />
+      </CardHeader>
+      <CardContent className="flex flex-col gap-6">
+        <div className="space-y-2">
+          {new Array(5).fill(0).map((_, index) => (
+            <div key={index} className="flex gap-2">
+              <Skeleton className="w-6 h-6" />
+              <Skeleton className="w-36 h-6" />
+            </div>
+          ))}
+        </div>
+        <div className="flex flex-col space-y-4">
+          <Label htmlFor="status">What is the status of this order?</Label>
+          <Skeleton className="h-9" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default OrderItemCardSkeleton;

--- a/src/components/skeletons/OrderStatusCardSkeleton.tsx
+++ b/src/components/skeletons/OrderStatusCardSkeleton.tsx
@@ -1,0 +1,51 @@
+import { AspectRatio } from "../ui/aspect-ratio";
+import { Progress } from "../ui/progress";
+import { Separator } from "../ui/separator";
+import { Skeleton } from "../ui/skeleton";
+
+const OrderStatusCardSkeleton = () => {
+  return (
+    <div className="space-y-10 bg-gray-50 dark:bg-gray-900 p-10 rounded-lg">
+      <h1 className="flex flex-col md:flex-row md:justify-between text-3xl font-bold gap-5">
+        <div className="flex gap-2">
+          <span>Order Status:</span> <Skeleton className="h-12 w-80" />
+        </div>
+        <div className="flex gap-2">
+          <span>Expected by:</span> <Skeleton className="h-12 w-20" />
+        </div>
+      </h1>
+      <Progress className="animate-pulse" value={25} />
+      <div className="grid md:grid-cols-2 gap-10">
+        <div className="space-y-5">
+          <div className="flex flex-col gap-2">
+            <div className="font-bold">Delivering to:</div>
+            <Skeleton className="h-6 w-48" />
+            <div className="flex gap-2">
+              <Skeleton className="h-6 w-40" /> <Skeleton className="h-6 w-40" />
+            </div>
+          </div>
+          <div className="flex flex-col gap-2">
+            <div className="font-bold">Your Order</div>
+            <ul className="flex flex-col gap-2">
+              {new Array(5).fill(0).map((_, index) => (
+                <li key={index} className="flex gap-2">
+                  <Skeleton className="h-6 w-40" /> x <Skeleton className="h-6 w-6" />
+                </li>
+              ))}
+            </ul>
+          </div>
+          <Separator />
+          <div className="flex flex-col gap-2">
+            <div className="font-bold">Total</div>
+            <Skeleton className="h-6 w-24" />
+          </div>
+        </div>
+        <AspectRatio ratio={16 / 5}>
+          <Skeleton className="w-full h-full rounded-md" />
+        </AspectRatio>
+      </div>
+    </div>
+  );
+};
+
+export default OrderStatusCardSkeleton;

--- a/src/components/skeletons/RestaurantInfoSkeleton.tsx
+++ b/src/components/skeletons/RestaurantInfoSkeleton.tsx
@@ -1,0 +1,30 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "../ui/card";
+import { Skeleton } from "../ui/skeleton";
+
+const RestaurantInfoSkeleton = () => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="font-bold text-3xl">
+          <Skeleton className="w-48 sm:w-80 h-9" />
+        </CardTitle>
+        <CardDescription className="flex gap-2">
+          <Skeleton className="w-16 h-5" /> <Skeleton className="w-16 h-5" />
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex gap-2 flex-wrap">
+        {new Array(3).fill(0).map((_, index) => (
+          <Skeleton key={index} className="w-20 h-6" />
+        ))}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default RestaurantInfoSkeleton;

--- a/src/components/skeletons/SearchPageSkeleton.tsx
+++ b/src/components/skeletons/SearchPageSkeleton.tsx
@@ -1,0 +1,33 @@
+import { Skeleton } from "../ui/skeleton";
+import CuisineFilterSkeleton from "./CuisineFilterSkeleton";
+import SearchResultCardSkeleton from "./SearchResultCardSkeleton";
+
+const SearchPageSkeleton = () => {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-[250px_1fr] gap-5">
+      <div id="cuisines-list">
+        {/* cuisines */}
+        <CuisineFilterSkeleton />
+      </div>
+      <div id="main-content" className="flex flex-col gap-5">
+        {/* search bar */}
+        <Skeleton className="border-2 rounded-full h-16 flex justify-end items-center px-4 gap-4">
+          <Skeleton className="w-24 h-9 rounded-full bg-background" />
+          <Skeleton className="w-24 h-9 rounded-full bg-background" />
+        </Skeleton>
+        {/* search results */}
+        {new Array(5).fill(0).map((_, index) => (
+          <SearchResultCardSkeleton key={index} />
+        ))}
+        {/* pagination tabs */}
+        <div className="flex justify-center gap-2">
+          {new Array(5).fill(0).map((_, index) => (
+            <Skeleton key={index} className="border-2 rounded-lg w-9 h-9" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SearchPageSkeleton;

--- a/src/components/skeletons/SearchResultCardSkeleton.tsx
+++ b/src/components/skeletons/SearchResultCardSkeleton.tsx
@@ -1,0 +1,36 @@
+import { AspectRatio } from "../ui/aspect-ratio";
+import { Skeleton } from "../ui/skeleton";
+
+const SearchResultCardSkeleton = () => {
+  return (
+    <div className="grid lg:grid-cols-[2fr_3fr] gap-5 group">
+      <AspectRatio ratio={16 / 6}>
+        <Skeleton className="rounded-xl w-full h-full" />
+      </AspectRatio>
+      <div>
+        <h3 className="text-xl font-bold mb-4 group-hover:underline">
+          <Skeleton className="w-60 h-7" />
+        </h3>
+        <div id="card-content" className="grid lg:grid-cols-2 gap-2">
+          <div className="flex flex-row flex-wrap gap-2">
+            {new Array(3).fill(0).map((_, index) => (
+              <span className="flex" key={index}>
+                <Skeleton className="w-16 h-6" />
+              </span>
+            ))}
+          </div>
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-1 text-greeen-600">
+              <Skeleton className="w-24 h-6" />
+            </div>
+            <div className="flex items-center gap-1">
+              <Skeleton className="w-48 h-6" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SearchResultCardSkeleton;

--- a/src/components/skeletons/UserProfileFormSkeleton.tsx
+++ b/src/components/skeletons/UserProfileFormSkeleton.tsx
@@ -1,0 +1,48 @@
+import { Button } from "../ui/button";
+import { Skeleton } from "../ui/skeleton";
+
+type Props = {
+  title?: string;
+  buttonText?: string;
+};
+
+const UserProfileFormSkeleton = ({
+  title = "User Profile Form",
+  buttonText = "Submit",
+}: Props) => {
+  return (
+    <form className="space-y-4 bg-gray-100 dark:bg-gray-900 rounded-lg p-5 md:p-10">
+      <div>
+        <h2 className="font-bold text-2xl">{title}</h2>
+        <p className="text-sm">View and change your profile information here</p>
+      </div>
+      <div className="flex flex-col space-y-2">
+        <label>Email</label>
+        <Skeleton className="h-9 bg-background" />
+      </div>
+      <div className="flex flex-col space-y-2">
+        <label>Name</label>
+        <Skeleton className="h-9 bg-background" />
+      </div>
+      <div className="flex flex-col md:flex-row gap-4 ">
+        <div className="flex flex-col flex-1 space-y-2">
+          <label>Address Line 1</label>
+          <Skeleton className="h-9 bg-background" />
+        </div>
+        <div className="flex flex-col flex-1 space-y-2">
+          <label>City</label>
+          <Skeleton className="h-9 bg-background" />
+        </div>
+        <div className="flex flex-col flex-1 space-y-2">
+          <label>Country</label>
+          <Skeleton className="h-9 bg-background" />
+        </div>
+      </div>
+      <Button type="submit" className="bg-blue-500 text-md" disabled>
+        {buttonText}
+      </Button>
+    </form>
+  );
+};
+
+export default UserProfileFormSkeleton;

--- a/src/components/skeletons/UserProfileFormSkeleton.tsx
+++ b/src/components/skeletons/UserProfileFormSkeleton.tsx
@@ -38,7 +38,7 @@ const UserProfileFormSkeleton = ({
           <Skeleton className="h-9 bg-background" />
         </div>
       </div>
-      <Button type="submit" className="bg-blue-500 text-md" disabled>
+      <Button type="submit" className="bg-blue-500 dark:bg-blue-700 text-md" disabled>
         {buttonText}
       </Button>
     </form>

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-primary/10", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/forms/user-profile-form/UserProfileForm.tsx
+++ b/src/forms/user-profile-form/UserProfileForm.tsx
@@ -132,7 +132,7 @@ const UserProfileForm = ({
         {isLoading ? (
           <LoadingButton />
         ) : (
-          <Button type="submit" className="bg-blue-500 text-md">
+          <Button type="submit" className="bg-blue-500 dark:bg-blue-700 text-md">
             {buttonText}
           </Button>
         )}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -37,7 +37,11 @@ const router = createBrowserRouter([
       },
       {
         path: "auth-callback",
-        element: <AuthCallbackPage />,
+        element: (
+          <Layout>
+            <AuthCallbackPage />
+          </Layout>
+        ),
       },
       {
         path: "search/:city",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -56,31 +56,23 @@ const router = createBrowserRouter([
         ),
       },
       {
-        element: <ProtectedRoute />,
+        element: (
+          <Layout>
+            <ProtectedRoute />
+          </Layout>
+        ),
         children: [
           {
             path: "order-status",
-            element: (
-              <Layout>
-                <OrderStatusPage />
-              </Layout>
-            ),
+            element: <OrderStatusPage />,
           },
           {
             path: "user-profile",
-            element: (
-              <Layout>
-                <UserProfilePage />
-              </Layout>
-            ),
+            element: <UserProfilePage />,
           },
           {
             path: "manage-restaurant",
-            element: (
-              <Layout>
-                <ManageRestaurantPage />
-              </Layout>
-            ),
+            element: <ManageRestaurantPage />,
           },
         ],
       },

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -23,7 +23,7 @@ const AuthCallbackPage = () => {
     navigate("/");
   }, [createUser, navigate, user]);
 
-  return <>AuthCallbackPage Loading...</>;
+  return <></>;
 };
 
 export default AuthCallbackPage;

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -9,6 +9,7 @@ import { AspectRatio } from "@radix-ui/react-aspect-ratio";
 import { MenuItem as MenuItemType } from "@/types";
 import { UserFormData } from "@/forms/user-profile-form/UserProfileForm";
 import { useCreateCheckoutSession } from "@/api/OrderApi";
+import DetailPageSkeleton from "@/components/skeletons/DetailPageSkeleton";
 
 export type CartItem = {
   _id: string;
@@ -104,7 +105,7 @@ const DetailPage = () => {
   };
 
   if (isLoading || !restaurant) {
-    return <div>Detail page loading...</div>;
+    return <DetailPageSkeleton />;
   }
 
   return (

--- a/src/pages/ManageRestaurantPage.tsx
+++ b/src/pages/ManageRestaurantPage.tsx
@@ -1,10 +1,9 @@
 import {
   useCreateMyRestaurant,
   useGetMyRestaurant,
-  useGetMyRestaurantOrders,
   useUpdateMyRestaurant,
 } from "@/api/MyRestaurantApi";
-import OrderItemCard from "@/components/OrderItemCard";
+import OrderItems from "@/components/OrderItems";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import ManageRestaurantForm from "@/forms/manage-restaurant-form/ManageRestaurantForm";
 
@@ -14,7 +13,6 @@ const ManageRestaurantPage = () => {
     useCreateMyRestaurant();
   const { updateRestaurant, isPending: isUpdatePending } =
     useUpdateMyRestaurant();
-  const { orders } = useGetMyRestaurantOrders();
 
   if (isLoading) {
     return <span>ManageRestaurantPage Loading...</span>;
@@ -38,12 +36,7 @@ const ManageRestaurantPage = () => {
         value="orders"
         className="space-y-5 bg-gray-50 dark:bg-gray-900 rounded-lg p-4 md:p-7 lg:p-10"
       >
-        <h2 className="font-bold text-2xl">
-          {orders?.length || 0} {(orders?.length || 0) > 1 ? "orders" : "order"}
-        </h2>
-        {orders?.map((order) => (
-          <OrderItemCard order={order} />
-        ))}
+        <OrderItems />
       </TabsContent>
       <TabsContent value="manage-restaurant">
         <ManageRestaurantForm

--- a/src/pages/ManageRestaurantPage.tsx
+++ b/src/pages/ManageRestaurantPage.tsx
@@ -4,6 +4,7 @@ import {
   useUpdateMyRestaurant,
 } from "@/api/MyRestaurantApi";
 import OrderItems from "@/components/OrderItems";
+import ManageRestaurantFormSkeleton from "@/components/skeletons/ManageRestaurantFormSkeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import ManageRestaurantForm from "@/forms/manage-restaurant-form/ManageRestaurantForm";
 
@@ -13,10 +14,6 @@ const ManageRestaurantPage = () => {
     useCreateMyRestaurant();
   const { updateRestaurant, isPending: isUpdatePending } =
     useUpdateMyRestaurant();
-
-  if (isLoading) {
-    return <span>ManageRestaurantPage Loading...</span>;
-  }
 
   let onSave = createRestaurant;
   let isPending = isCreatePending;
@@ -39,11 +36,15 @@ const ManageRestaurantPage = () => {
         <OrderItems />
       </TabsContent>
       <TabsContent value="manage-restaurant">
-        <ManageRestaurantForm
-          restaurant={restaurant}
-          onSave={onSave}
-          isLoading={isPending}
-        />
+        {isLoading ? (
+          <ManageRestaurantFormSkeleton />
+        ) : (
+          <ManageRestaurantForm
+            restaurant={restaurant}
+            onSave={onSave}
+            isLoading={isPending}
+          />
+        )}
       </TabsContent>
     </Tabs>
   );

--- a/src/pages/OrderStatusPage.tsx
+++ b/src/pages/OrderStatusPage.tsx
@@ -1,13 +1,20 @@
 import { useGetMyOrders } from "@/api/OrderApi";
 import OrderStatusDetail from "@/components/OrderStatusDetail";
 import OrderStatusHeader from "@/components/OrderStatusHeader";
+import OrderStatusCardSkeleton from "@/components/skeletons/OrderStatusCardSkeleton";
 import { AspectRatio } from "@/components/ui/aspect-ratio";
 
 const OrderStatusPage = () => {
   const { orders, isLoading } = useGetMyOrders();
 
   if (isLoading) {
-    return <div>Order status page Loading...</div>;
+    return (
+      <div className="space-y-10">
+        {new Array(5).fill(0).map((_, index) => (
+          <OrderStatusCardSkeleton key={index} />
+        ))}
+      </div>
+    );
   }
 
   if (!orders || orders.length === 0) {

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -8,6 +8,7 @@ import SearchResultCard from "@/components/SearchResultCard";
 import SearchResultInfo from "@/components/SearchResultInfo";
 import CuisineFilter from "@/components/CuisineFilter";
 import SortOptionDropdown from "@/components/SortOptionDropdown";
+import SearchPageSkeleton from "@/components/skeletons/SearchPageSkeleton";
 
 export type SearchState = {
   searchQuery: string;
@@ -69,7 +70,7 @@ const SearchPage = () => {
   };
 
   if (isLoading) {
-    return <div>Search page loading...</div>;
+    return <SearchPageSkeleton />;
   }
 
   if (!results?.data || !city) {
@@ -97,7 +98,10 @@ const SearchPage = () => {
         />
         <div className="flex flex-col md:flex-row justify-between items-center gap-3">
           <SearchResultInfo city={city} total={results.pagination.total} />
-          <SortOptionDropdown onChange={(value) => setSortOption(value)} sortOption={searchState.sortOption} />
+          <SortOptionDropdown
+            onChange={(value) => setSortOption(value)}
+            sortOption={searchState.sortOption}
+          />
         </div>
         {results.data.map((restaurant) => (
           <SearchResultCard key={restaurant._id} restaurant={restaurant} />

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -1,4 +1,5 @@
 import { useGetMyUser, useUpdateMyUser } from "@/api/MyUserApi";
+import UserProfileFormSkeleton from "@/components/skeletons/UserProfileFormSkeleton";
 import UserProfileForm from "@/forms/user-profile-form/UserProfileForm";
 
 const UserProfilePage = () => {
@@ -6,7 +7,7 @@ const UserProfilePage = () => {
   const { currentUser, isLoading: isGetLoading } = useGetMyUser();
 
   if (isGetLoading) {
-    return <span>UserProfilePage Loading...</span>;
+    return <UserProfileFormSkeleton />;
   }
 
   if (!currentUser) {


### PR DESCRIPTION
Added skeleton loading states across 6 pages:

- Search page with restaurant card grid
- Restaurant details with menu items
- Order status with timeline
- User profile with personal info
- Order management section with list view
- Restaurant management with settings

All skeletons feature:

- Shimmer animations
- Responsive layouts
- Consistent spacing
- Smooth transitions

Improves UX during data loading phases.

**Screenshots of implemented skeleton states for each page**

- Search page
![image](https://github.com/user-attachments/assets/012c9ad8-227f-4f47-b284-bb070ab049c5)

- Restaurant Details page
![image](https://github.com/user-attachments/assets/45516cf9-52e6-44ec-b162-8fde74422d62)

- Order status page
![image](https://github.com/user-attachments/assets/f3d4d37e-f066-4be1-9039-607cccf9ecce)

- User profile page
![image](https://github.com/user-attachments/assets/658fca81-8aef-4f97-b83c-9a04546a13c8)

- Order section of manage restaurant page
![image](https://github.com/user-attachments/assets/15cb3bd9-419f-428e-9b2b-f59f55d32dff)

- Manage restaurant section of manage restaurant page
![image](https://github.com/user-attachments/assets/2a7a0504-951d-417e-bd25-15c8ee3eae58)
